### PR TITLE
Fix refresh/sync button to call sync_gostanford.py before refresh_data.py

### DIFF
--- a/server.js
+++ b/server.js
@@ -93,7 +93,20 @@ app.post('/api/refresh', async (req, res) => {
   }
   refreshInProgress = true;
   try {
-    const result = await new Promise((resolve, reject) => {
+    // Step 1: Sync with GoStanford to fetch latest meet data
+    const syncResult = await new Promise((resolve, reject) => {
+      exec('python3 scripts/sync_gostanford.py', {
+        cwd: __dirname,
+        timeout: 60000,
+        encoding: 'utf-8',
+      }, (err, stdout, stderr) => {
+        if (err) return reject(err);
+        resolve(stdout);
+      });
+    });
+
+    // Step 2: Refresh/update data timestamps and metadata
+    const refreshResult = await new Promise((resolve, reject) => {
       exec('python3 scripts/refresh_data.py', {
         cwd: __dirname,
         timeout: 60000,
@@ -107,14 +120,29 @@ app.post('/api/refresh', async (req, res) => {
     // Reload meets.json into memory
     loadMeetsData();
 
-    let summary;
+    let syncSummary = { raw: syncResult.trim() };
+    let refreshSummary = { raw: refreshResult.trim() };
+    
     try {
-      summary = JSON.parse(result.trim());
+      syncSummary = JSON.parse(syncResult.trim());
     } catch (e) {
-      summary = { raw: result.trim() };
+      // Keep the raw version
+    }
+    
+    try {
+      refreshSummary = JSON.parse(refreshResult.trim());
+    } catch (e) {
+      // Keep the raw version
     }
 
-    res.json({ success: true, summary });
+    res.json({ 
+      success: true, 
+      summary: {
+        sync: syncSummary,
+        refresh: refreshSummary,
+        meetsLoaded: meetsData.length
+      }
+    });
   } catch (err) {
     console.error('Refresh failed:', err.message);
     res.status(500).json({ success: false, error: err.message });


### PR DESCRIPTION
## Summary

Fixes the refresh/sync button on the frontend to properly fetch and update meet data from GoStanford.

## Changes

- Updated POST `/api/refresh` handler in server.js to:
  1. Call `sync_gostanford.py` first to sync with GoStanford schedule
  2. Then call `refresh_data.py` to update data timestamps
  3. Reload meets.json into memory with the latest data
  4. Return a comprehensive summary with results from both scripts

## Verification

- ✅ March 14, 2026 senior night quad meet has individual match results for all 4 opponents
- ✅ /api/refresh endpoint now executes both sync_gostanford.py and refresh_data.py
- ✅ Refresh button will update meets.json and reload in-memory data
- ✅ Both Python scripts run successfully and return proper JSON summaries
- ✅ JavaScript syntax validation passed

Addresses issue #6